### PR TITLE
Implemented call to endpoint to handle storing the final report

### DIFF
--- a/app/agents/compiler.py
+++ b/app/agents/compiler.py
@@ -1,12 +1,14 @@
+import json
+import logging
 from typing import List
 
-from langchain_core.messages import SystemMessage, HumanMessage
+import requests
+from langchain_core.messages import HumanMessage, SystemMessage
 
 from app.config.config import get_settings
 from app.utils.llms import LLMConfig, LLMManager, LLMType
-from app.utils.prompts import FINAL_SECTION_WRITER, FINAL_REPORT_FORMAT
-from app.utils.state import ReportState, Section, SectionState
-import logging
+from app.utils.prompts import FINAL_REPORT_FORMAT, FINAL_SECTION_WRITER
+from app.utils.state import Section
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -29,7 +31,7 @@ class ReportCompiler:
         llm_config = LLMConfig(
             temperature=0.0,  # Use deterministic output for compilation
             streaming=True,
-            max_tokens=4000  # Larger context for final compilation
+            max_tokens=4000,  # Larger context for final compilation
         )
         self.llm_manager = LLMManager(llm_config)
         self.primary_llm = self.llm_manager.get_llm(LLMType.GPT_4O_MINI)
@@ -46,27 +48,40 @@ class ReportCompiler:
         formatted_str = ""
         for idx, section in enumerate(sections, 1):
             formatted_str += f"""
-                            {'=' * 60}
+                            {"=" * 60}
                             Section {idx}: {section.name}
-                            {'=' * 60}
+                            {"=" * 60}
                             Description:
                             {section.description}
                             Requires Research: 
                             {section.research}
                             
                             Content:
-                            {section.content if section.content else '[Not yet written]'}
+                            {section.content if section.content else "[Not yet written]"}
                             """
         return formatted_str
+
+    async def save_final_report(self, url, assignment_id, final_report):
+        payload = {"assignmentId": assignment_id, "markdownContent": final_report}
+        json_payload = json.dumps(payload)
+
+        headers = {"Content-Type": "application/json"}
+
+        response = requests.post(url, headers=headers, data=json_payload)
+
+        if response.status_code == 200:
+            logger.debug("Report saved successfully!")
+        else:
+            logger.error(
+                f"Request failed with status code: {str(response.status_code)}\nError content: {response.text}"
+            )
 
     async def send_progress(self, message: str, data: dict = None):
         """Send progress updates through websocket"""
         if self.websocket:
-            await self.websocket.send_json({
-                "type": "compiler_progress",
-                "message": message,
-                "data": data
-            })
+            await self.websocket.send_json(
+                {"type": "compiler_progress", "message": message, "data": data}
+            )
 
     async def gather_completed_sections(self, state: dict) -> dict:
         """Gather and format completed sections for context."""
@@ -78,7 +93,7 @@ class ReportCompiler:
             # Retornar estado completo actualizado
             return {
                 **state,  # Mantener estado existente
-                "report_sections_from_research": formatted_sections
+                "report_sections_from_research": formatted_sections,
             }
 
         except Exception as e:
@@ -90,22 +105,26 @@ class ReportCompiler:
         try:
             section = state["section"]
             context = state.get("report_sections_from_research", "")
-            
+
             await self.send_progress(f"Writing final section: {section.name}")
 
             system_instructions = FINAL_SECTION_WRITER.format(
                 section_title=section.name,
                 section_topic=section.description,
-                context=context
+                context=context,
             )
 
-            section_content = await self.primary_llm.ainvoke([
-                SystemMessage(content=system_instructions),
-                HumanMessage(content="Generate a report section based on the provided sources.")
-            ])
+            section_content = await self.primary_llm.ainvoke(
+                [
+                    SystemMessage(content=system_instructions),
+                    HumanMessage(
+                        content="Generate a report section based on the provided sources."
+                    ),
+                ]
+            )
 
             section.content = section_content.content
-            
+
             # Solo retornar los campos que necesitamos actualizar
             return {
                 "completed_sections": state.get("completed_sections", []) + [section]
@@ -151,38 +170,53 @@ class ReportCompiler:
             # Generate final report with streaming
             system_instructions = FINAL_REPORT_FORMAT.format(
                 all_sections=all_sections,
-                report_organization=self.settings.report_structure
+                report_organization=self.settings.report_structure,
             )
 
             content_buffer = []
             logger.debug("Starting final report streaming generation")
-            
+
             # Stream the report generation
-            async for chunk in self.primary_llm.astream([
-                SystemMessage(content=system_instructions),
-                HumanMessage(content="Generate the final report with proper formatting and transitions in spanish")
-            ]):
+            async for chunk in self.primary_llm.astream(
+                [
+                    SystemMessage(content=system_instructions),
+                    HumanMessage(
+                        content="Generate the final report with proper formatting and transitions in spanish"
+                    ),
+                ]
+            ):
                 logger.debug(f"Received final report chunk: {chunk.content[:50]}...")
                 content_buffer.append(chunk.content)
-                
+
                 # Enviar el chunk al websocket
-                await self.send_progress("final_report_chunk", {
-                    "type": "report_content",
-                    "content": chunk.content,
-                    "is_complete": False
-                })
+                await self.send_progress(
+                    "final_report_chunk",
+                    {
+                        "type": "report_content",
+                        "content": chunk.content,
+                        "is_complete": False,
+                    },
+                )
 
             # Unir todo el contenido
             final_report = "".join(content_buffer)
-            
+
             # Enviar mensaje de completado
-            await self.send_progress("final_report_complete", {
-                "type": "report_content",
-                "content": final_report,
-                "is_complete": True
-            })
+            await self.send_progress(
+                "final_report_complete",
+                {
+                    "type": "report_content",
+                    "content": final_report,
+                    "is_complete": True,
+                },
+            )
 
             logger.debug("Final report compilation completed")
+            await self.save_final_report(
+                self.settings.store_mardown_endpoint,
+                state["assignment_id"],
+                final_report,
+            )
             return {"final_report": final_report}
 
         except Exception as e:

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -1,10 +1,11 @@
+import os
+from dataclasses import dataclass, fields
 from functools import lru_cache
-from typing import Optional, Any
-from pydantic_settings import BaseSettings
-from dataclasses import dataclass, field, fields
+from typing import Any, Optional
+
 from dotenv import load_dotenv
 from langchain_core.runnables import RunnableConfig
-import os
+from pydantic_settings import BaseSettings
 
 # Cargar las variables del archivo .env
 load_dotenv()
@@ -13,13 +14,14 @@ load_dotenv()
 @dataclass(kw_only=True)
 class LangGraphConfig:
     """Configuración específica para LangGraph"""
+
     number_of_queries: int = 2
     tavily_topic: str = "general"
     tavily_days: str = None
 
     @classmethod
     def from_runnable_config(
-            cls, config: Optional[RunnableConfig] = None
+        cls, config: Optional[RunnableConfig] = None
     ) -> "LangGraphConfig":
         """Crear configuración desde RunnableConfig de LangGraph"""
         configurable = (
@@ -362,6 +364,9 @@ Este marco asegura un análisis consistente de soluciones basadas en agentes. S�
     number_of_queries: int = 3
     tavily_topic: str = "general"
     tavily_days: Optional[int] = 7
+
+    # LOCAL ENDPOINTS
+    store_mardown_endpoint: str
 
     class Config:
         env_file = ".env"

--- a/app/utils/state.py
+++ b/app/utils/state.py
@@ -1,11 +1,13 @@
-from pydantic import BaseModel, Field
-from typing import List, Optional, Annotated, Dict
-from typing_extensions import TypedDict
 import operator
+from typing import Annotated, List, Optional
+
+from pydantic import BaseModel, Field
+from typing_extensions import TypedDict
 
 
 class Section(BaseModel):
     """Modelo para una sección de investigación"""
+
     id: str
     name: str = Field(
         description="Name for this section of the report.",
@@ -16,9 +18,7 @@ class Section(BaseModel):
     research: bool = Field(
         description="Whether to perform web research for this section of the report."
     )
-    content: str = Field(
-        description="The content of the section."
-    )
+    content: str = Field(description="The content of the section.")
 
 
 class Sections(BaseModel):
@@ -38,12 +38,17 @@ class Queries(BaseModel):
 
 
 class ReportState(TypedDict):
+    assignment_id: str
     topic: str
     sections: list[Section]
     final_report: str
     completed_sections: Annotated[list, operator.add]  # Send() API key
-    report_sections_from_research: str  # String of any completed sections from research to write final sections
-    websocket: Optional[object]  # Agregamos websocket manteniendo la estructura TypedDict
+    report_sections_from_research: (
+        str  # String of any completed sections from research to write final sections
+    )
+    websocket: Optional[
+        object
+    ]  # Agregamos websocket manteniendo la estructura TypedDict
 
 
 class ResearchState(BaseModel):
@@ -55,9 +60,15 @@ class SectionState(TypedDict):
     section: Section  # Report section
     search_queries: list[SearchQuery]  # List of search queries
     source_str: str  # String of formatted source content from web search
-    report_sections_from_research: str  # String of any completed sections from research to write final sections
-    completed_sections: list[Section]  # Final key we duplicate in outer state for Send() API
+    report_sections_from_research: (
+        str  # String of any completed sections from research to write final sections
+    )
+    completed_sections: list[
+        Section
+    ]  # Final key we duplicate in outer state for Send() API
 
 
 class SectionOutputState(TypedDict):
-    completed_sections: list[Section]  # Final key we duplicate in outer state for Send() API
+    completed_sections: list[
+        Section
+    ]  # Final key we duplicate in outer state for Send() API

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -1,12 +1,12 @@
 import logging
 from typing import List
+
 from fastapi import WebSocket
 
-from app.graph.director import GraphDirector
-from app.utils.state import ReportState
 from app.graph.report_graph import get_report_graph
 
 logger = logging.getLogger(__name__)
+
 
 class WebSocketManager:
     """Gestiona las conexiones WebSocket y el proceso de investigación"""
@@ -27,6 +27,7 @@ class WebSocketManager:
     async def handle_research(self, websocket: WebSocket, data: dict):
         """Maneja el proceso de investigación usando el grafo de LangGraph"""
         try:
+            assignment_id = data.get("assignmentId", "")
             title = data.get("title", "")
             description = data.get("description", "")
             if not title:
@@ -37,25 +38,25 @@ class WebSocketManager:
 
             # Crear estado inicial completo
             state = {
+                "assignment_id": assignment_id,
                 "topic": topic,
                 "sections": [],
                 "final_report": "",
                 "completed_sections": [],
                 "report_sections_from_research": "",  # Inicializar vacío
-                "websocket": websocket
+                "websocket": websocket,
             }
 
             logger.info(f"Iniciando investigación para: {title}")
-            
+
             # Enviar mensaje de inicio
-            await websocket.send_json({
-                "type": "research_start",
-                "message": "Starting research process",
-                "data": {
-                    "title": title,
-                    "status": "started"
+            await websocket.send_json(
+                {
+                    "type": "research_start",
+                    "message": "Starting research process",
+                    "data": {"title": title, "status": "started"},
                 }
-            })
+            )
 
             # Configurar el streaming
             async def handle_stream(message):
@@ -69,39 +70,36 @@ class WebSocketManager:
                 await handle_stream(chunk)
 
             # Mensaje final
-            await websocket.send_json({
-                "type": "research_complete",
-                "message": "Research completed successfully",
-                "data": {
-                    "title": title,
-                    "status": "completed"
+            await websocket.send_json(
+                {
+                    "type": "research_complete",
+                    "message": "Research completed successfully",
+                    "data": {"title": title, "status": "completed"},
                 }
-            })
+            )
 
         except Exception as e:
             logger.error(f"Error en investigación: {str(e)}", exc_info=True)
-            await websocket.send_json({
-                "type": "error",
-                "data": {"error": str(e)}
-            })
+            await websocket.send_json({"type": "error", "data": {"error": str(e)}})
 
     async def handle_message(self, websocket: WebSocket, data: dict):
         """Router de mensajes WebSocket"""
         try:
             message_type = data.get("type")
-            
+
             if message_type == "start_research":
                 await self.handle_research(websocket, data)
             else:
                 logger.warning(f"Tipo de mensaje no soportado: {message_type}")
-                await websocket.send_json({
-                    "type": "error",
-                    "data": {"error": f"Tipo de mensaje no soportado: {message_type}"}
-                })
+                await websocket.send_json(
+                    {
+                        "type": "error",
+                        "data": {
+                            "error": f"Tipo de mensaje no soportado: {message_type}"
+                        },
+                    }
+                )
 
         except Exception as e:
             logger.error(f"Error procesando mensaje: {str(e)}", exc_info=True)
-            await websocket.send_json({
-                "type": "error",
-                "data": {"error": str(e)}
-            })
+            await websocket.send_json({"type": "error", "data": {"error": str(e)}})


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

## TL;DR

Partial Closes #37

## 📑 Description
Se añade el llamado al endpoint para el almacenamiento del reporte final, obteniendo el `assignment_id` desde el frontend y utilizando los estados de `LangGraph` para llevar el ID hasta el compilador.

## 🔄 List of Changes
- Se añadió el valor `assignment_id` al estado del websocket y al `ReportState`.
- Al final de la generación del reporte se añade el llamado al endpoint correspondiente.

## ✅ Checks
- [x] Mi pull request se adhiere al estilo de código de este proyecto.
- [ ] Mi código requiere cambios en la documentación.
- [ ] He actualizado la documentación según sea necesario.
- [x] Todas las pruebas han pasado.

## ℹ Additional Information
Pruebas unitarias se realizaron manualmente para verificar el funcionamiento correcto.
